### PR TITLE
ELB should DependsOn VPC-gateway attachment

### DIFF
--- a/cfn/core.yml
+++ b/cfn/core.yml
@@ -666,6 +666,7 @@ Resources:
 
   MythicalLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    DependsOn: GatewayAttachement
     Properties:
       Name: !Sub alb-${AWS::StackName}
       Scheme: internet-facing


### PR DESCRIPTION
ELB should DependsOn VPC-gateway attachment as per https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html

*Issue #, if available:*

*Description of changes:*
When deploying the core.yml CloudFormation, my stack failed

MythicalLoadBalancer | CREATE_FAILED | VPC   vpc-0742c01757373579f has no internet gateway (Service:   AmazonElasticLoadBalancingV2; Status Code: 400; Error Code: InvalidSubnet;   Request ID: 2afefea2-e756-4cc2-9692-febca766a480) | AWS::ElasticLoadBalancingV2::LoadBalance
-- | -- | -- | --

I noted that at the time of this event
* The IGW creation had not even started
* `PublicSubnetOneRouteTableAssociation` was still  `CREATE_IN_PROGRESS`

I then found [this documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html) which confirms that the `DependsOn` is needed:

> Currently, the following resources depend on a VPC-gateway attachment when they have an associated public IP address and are in a VPC:
> * Auto Scaling groups
> * Amazon EC2 instances
> * Elastic Load Balancing load balancers
> * Elastic IP addresses
> * Amazon RDS database instances
> * Amazon VPC routes that include the Internet gateway

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
