### PR TITLE
Improve cleanup instructions at end of lab 5 same and in top level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ If you're attending an AWS event and are provided an account to use, you can ign
 
 **If you are using your own account**, it is **VERY** important you clean up resources created during the workshop. Follow these steps once you're done going through the workshop to delete resources that were created:
 
-1. Delete any manually created assets - for example, Global Accelerator from lab 4 (if you got to that point).
+1. Delete any manually created assets - for example:
+      * DynamoDB Global Tables replica from lab 3
+      * Global Accelerator from lab 4
 2. Navigate to the [CloudFormation dashboard](https://console.aws.amazon.com/cloudformation/home#/stacks) in the primary region and click on your workshop stack name to load stack details.
 3. Click **Delete** to delete the stack.
 4. Repeat steps 2-3 for the secondary region.

--- a/lab-5-loadtest/README.md
+++ b/lab-5-loadtest/README.md
@@ -247,7 +247,9 @@ If you're attending an AWS event and are provided an account to use, you can ign
 
 **If you are using your own account**, it is **VERY** important you clean up resources created during the workshop. Follow these steps to delete the main workshop CloudFormation stack once you're done going through the workshop:
 
-1. Delete any manually created assets - for example, Global Accelerator from lab 4 (if you got to that point).
+1. Delete any manually created assets - for example:
+      * DynamoDB Global Tables replica from lab 3
+      * Global Accelerator from lab 4
 2. Navigate to the [CloudFormation dashboard](https://console.aws.amazon.com/cloudformation/home#/stacks) in the primary region and click on your workshop stack name to load stack details.
 3. Click **Delete** to delete the stack.
 4. Repeat steps 2-3 for the secondary region.

--- a/lab-5-loadtest/README.md
+++ b/lab-5-loadtest/README.md
@@ -247,8 +247,10 @@ If you're attending an AWS event and are provided an account to use, you can ign
 
 **If you are using your own account**, it is **VERY** important you clean up resources created during the workshop. Follow these steps to delete the main workshop CloudFormation stack once you're done going through the workshop:
 
-1. Navigate to the [CloudFormation dashboard](https://console.aws.amazon.com/cloudformation/home#/stacks) and click on your workshop stack name to load stack details
-2. Click **Delete** to delete the stack
+1. Delete any manually created assets - for example, Global Accelerator from lab 4 (if you got to that point).
+2. Navigate to the [CloudFormation dashboard](https://console.aws.amazon.com/cloudformation/home#/stacks) in the primary region and click on your workshop stack name to load stack details.
+3. Click **Delete** to delete the stack.
+4. Repeat steps 2-3 for the secondary region.
 
 There are helper Lambda functions that should clean things up when you delete the main stack. However, if there's a stack deletion failure due to a race condition, follow these steps:
 


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
* Cleanup instructions at end of lab 5 will fail if student completed lab 4 and created a Global Accelerator.  The cleanup instructions in the top level README **do** include this step, so I copied those same instructions to Lab5
* Cleanup instructions also need to include deletion of DDB Global Tables replica

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
